### PR TITLE
Added hard check for Python version 3

### DIFF
--- a/spotter.py
+++ b/spotter.py
@@ -7,6 +7,10 @@ from base.obfuscator import Obfuscator
 from base.psh import pshTemplate
 from base.csi import csInjectorTemplate
 
+if sys.version_info < (3, 0):
+    sys.stdout.write("[-] Please use Python 3.x\n")
+    sys.exit(1)
+
 banner = """
                  _   _            
                 | | | |           


### PR DESCRIPTION
This is to prevent people from accidentally running with 2.x, which will cause the encryption pieces to fail.